### PR TITLE
サイズ画面の追加及びオブジェクトのレイアウトを調整

### DIFF
--- a/main/app/build.gradle
+++ b/main/app/build.gradle
@@ -66,9 +66,9 @@ dependencies {
     // navigation
     implementation "androidx.navigation:navigation-compose:2.4.0-alpha09"
 
-    // ConstraintLayout
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.0-beta02"
-
     // viewModel
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0-beta01"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0-rc01"
+
+    // accompanist
+    implementation "com.google.accompanist:accompanist-pager-indicators:0.19.0"
 }

--- a/main/app/src/main/java/com/example/seatassist/MainActivity.kt
+++ b/main/app/src/main/java/com/example/seatassist/MainActivity.kt
@@ -15,11 +15,13 @@ import com.example.seatassist.ui.main.MainViewModel
 import com.example.seatassist.ui.members.MembersScreen
 import com.example.seatassist.ui.size.SizeScreen
 import com.example.seatassist.ui.theme.SeatAssistTheme
+import com.google.accompanist.pager.ExperimentalPagerApi
 
 class MainActivity : ComponentActivity() {
 
     private val mainViewModel = MainViewModel()
 
+    @ExperimentalPagerApi
     @ExperimentalMaterialApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,6 +31,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+@ExperimentalPagerApi
 @ExperimentalMaterialApi
 @Composable
 fun SeatAssistApp(mainViewModel: MainViewModel) {
@@ -42,6 +45,7 @@ fun SeatAssistApp(mainViewModel: MainViewModel) {
     }
 }
 
+@ExperimentalPagerApi
 @ExperimentalMaterialApi
 @Composable
 fun SeatAssistNavHost(
@@ -58,6 +62,9 @@ fun SeatAssistNavHost(
             // Main Compose
             MainScreen(
                 numberText = mainViewModel.numberText.value,
+                sizeValue = mainViewModel.sizeValue.value,
+                scaleValue = mainViewModel.scaleValue,
+                dragColor = mainViewModel.color.value,
                 offsetList = mainViewModel.offsetList,
                 onAddObject = mainViewModel::addObject,
                 onRemoveObject = mainViewModel::removeObject,
@@ -82,7 +89,12 @@ fun SeatAssistNavHost(
         }
         composable(route = SeatAssistScreen.Size.name) {
             // Size Compose
-            SizeScreen()
+            SizeScreen(
+                scaleValue = mainViewModel.scaleValue,
+                sizeValue = mainViewModel.sizeValue.value,
+                onEditScale = mainViewModel::editScale,
+                onEditSize = mainViewModel::editSize
+            )
         }
     }
 }

--- a/main/app/src/main/java/com/example/seatassist/data/SeatAssistData.kt
+++ b/main/app/src/main/java/com/example/seatassist/data/SeatAssistData.kt
@@ -1,6 +1,8 @@
 package com.example.seatassist.data
 
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 
 data class MembersData(
     var id: Int,
@@ -10,5 +12,12 @@ data class MembersData(
 data class OffsetData(
     var id: Int,
     var offsetX: MutableState<Float>,
-    var offsetY: MutableState<Float>
+    var offsetY: MutableState<Float>,
+    var color: Color,
+    var size: Dp
+)
+
+data class ScaleData(
+    var scale: MutableState<Float>,
+    var rotation: MutableState<Float>
 )

--- a/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
@@ -2,9 +2,13 @@ package com.example.seatassist.ui.main
 
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import com.example.seatassist.data.MembersData
 import com.example.seatassist.data.OffsetData
+import com.example.seatassist.data.ScaleData
 
 class MainViewModel : ViewModel() {
 
@@ -17,8 +21,20 @@ class MainViewModel : ViewModel() {
 
     var offsetList = mutableStateListOf<OffsetData>()
 
-    fun addObject(id: Int, OffsetX: Float, OffsetY: Float) {
-        offsetList.add(OffsetData(id, mutableStateOf(OffsetX), mutableStateOf(OffsetY)))
+    var sizeValue = mutableStateOf(50.dp)
+
+    var color = mutableStateOf(Color(0xFFDBD2AC))
+
+    fun addObject(id: Int, OffsetX: Float, OffsetY: Float, color: Color, size: Dp) {
+        offsetList.add(
+            OffsetData(
+                id,
+                mutableStateOf(OffsetX),
+                mutableStateOf(OffsetY),
+                color,
+                size,
+            )
+        )
     }
 
     fun removeObject(id: Int) {
@@ -57,5 +73,23 @@ class MainViewModel : ViewModel() {
 
     fun editName(id: Int, newName: String) {
         membersList[id].name.value = newName
+    }
+
+
+    // SizeScreen
+    var scaleValue = ScaleData(scale = mutableStateOf(1F), rotation = mutableStateOf(0F))
+
+
+    fun editSize(newSize: Dp) {
+        sizeValue.value = newSize
+    }
+
+    fun editColor(newColor: Color) {
+        color.value = newColor
+    }
+
+    fun editScale(newScale: Float, newRotation: Float) {
+        scaleValue.scale.value *= newScale
+        scaleValue.rotation.value += newRotation
     }
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/size/SizeScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/size/SizeScreen.kt
@@ -1,8 +1,142 @@
 package com.example.seatassist.ui.size
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.seatassist.data.ScaleData
+import com.google.accompanist.pager.ExperimentalPagerApi
+
+@ExperimentalPagerApi
+@Composable
+fun SizeScreen(
+    scaleValue: ScaleData,
+    sizeValue: Dp,
+    onEditScale: (Float, Float) -> Unit,
+    onEditSize: (Dp) -> Unit
+) {
+    Surface(
+        color = MaterialTheme.colors.primary,
+        contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.primary),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Card(
+                shape = RoundedCornerShape(16.dp),
+                backgroundColor = MaterialTheme.colors.primaryVariant,
+                contentColor = MaterialTheme.colors.onPrimary,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .height(300.dp)
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    TransformableSample(
+                        scaleValue = scaleValue,
+                        onEditScale = onEditScale,
+                        sizeValue = sizeValue
+                    )
+                }
+            }
+
+
+            Row(
+                horizontalArrangement = Arrangement.SpaceAround,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
+                for (i in 0..2) {
+                    SeatCard(
+                        objectSize = (50 + 25 * i).dp,
+                        spacerSize = (8 + 12.5 * (2 - i)).dp,
+                        scaleValue = scaleValue,
+                        modifier = Modifier.padding(top = (12.5 * (2 - i)).dp),
+                        onEditSize = onEditSize
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun SizeScreen() {
+fun SeatCard(
+    objectSize: Dp,
+    spacerSize: Dp,
+    scaleValue: ScaleData,
+    modifier: Modifier,
+    onEditSize: (Dp) -> Unit
+) {
+    Card(
+        backgroundColor = MaterialTheme.colors.primary,
+        contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.primary),
+        modifier = modifier,
+        elevation = 0.dp,
 
+        ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(objectSize)
+                    .clip(shape = RoundedCornerShape(4.dp))
+                    .background(MaterialTheme.colors.onPrimary)
+                    .clickable {
+                        onEditSize(objectSize)
+                        scaleValue.scale.value = 1F
+                        scaleValue.rotation.value = 0F
+                    }
+            )
+            Spacer(modifier = Modifier.size(spacerSize))
+            Text(
+                text = objectSize.value.toInt().toString() + ".dp",
+                style = MaterialTheme.typography.h4,
+                fontSize = 20.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+fun TransformableSample(
+    scaleValue: ScaleData,
+    onEditScale: (Float, Float) -> Unit,
+    sizeValue: Dp
+) {
+    val state = rememberTransformableState { zoomChange, _, rotationChange ->
+        onEditScale(zoomChange, rotationChange)
+    }
+    Box(
+        Modifier
+            .size(sizeValue * 2)
+            .graphicsLayer(
+                scaleX = scaleValue.scale.value,
+                scaleY = scaleValue.scale.value,
+                rotationZ = scaleValue.rotation.value,
+
+                )
+            .transformable(state = state)
+            .background(MaterialTheme.colors.onPrimary)
+            .size(100.dp)
+    )
 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.1"
+        classpath "com.android.tools.build:gradle:7.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
# 概要
1. サイズ画面の追加
2. オブジェクトのレイアウトの調整

# 変更点（UIに変更があればスクショを貼る）
1. サイズ画面の追加
オブジェクトのサイズを調整するための画面を追加．自由にサイズを決定できるようにした．

2. オブジェクトのレイアウトの調整
影の追加と，形の調整．

###  サイズ変更画面
<img src="https://user-images.githubusercontent.com/81143699/136457632-7a2f1eef-a990-4415-a246-a0660a8d3566.png" width=300>

### オブジェクトは配置画面
<img src="https://user-images.githubusercontent.com/81143699/136457785-b031f13f-67af-4141-ac34-0c9ddd6c8dd8.png" width=300>

# Issue
#12 

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
