### PR TITLE
[UsageScreen]使い方画面の作成

### DIFF
--- a/main/app/src/main/java/com/example/seatassist/MainActivity.kt
+++ b/main/app/src/main/java/com/example/seatassist/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.core.graphics.scaleMatrix
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -16,6 +17,7 @@ import com.example.seatassist.ui.members.MembersScreen
 import com.example.seatassist.ui.size.SizeScreen
 import com.example.seatassist.ui.theme.SeatAssistTheme
 import com.example.seatassist.ui.start.StartScreen
+import com.example.seatassist.ui.usage.UsageScreen
 import com.google.accompanist.pager.ExperimentalPagerApi
 
 class MainActivity : ComponentActivity() {
@@ -61,7 +63,14 @@ fun SeatAssistNavHost(
     ) {
         composable(route = SeatAssistScreen.Start.name){
             StartScreen(
+                onUsageClick = { navController.navigate(SeatAssistScreen.Usage.name)},
                 onStartClick = { navController.navigate(SeatAssistScreen.Main.name) }
+            )
+        }
+        composable(route = SeatAssistScreen.Usage.name) {
+            // Usage Compose
+            UsageScreen (
+                onNavigationClick = { navController.navigate(SeatAssistScreen.Start.name) }
             )
         }
         composable(route = SeatAssistScreen.Main.name) {

--- a/main/app/src/main/java/com/example/seatassist/SeatAssistScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/SeatAssistScreen.kt
@@ -5,5 +5,6 @@ enum class SeatAssistScreen() {
     Members(),
     Number(),
     Size(),
-    Start()
+    Start(),
+    Usage()
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
@@ -23,6 +23,7 @@ import com.example.seatassist.R
 @ExperimentalMaterialApi
 @Composable
 fun StartScreen(
+    onUsageClick:() -> Unit,
     onStartClick:() -> Unit
 ) {
 
@@ -56,7 +57,7 @@ fun StartScreen(
                 }
             }
             StartButton("Start", onStartClick)    // スタートボタン
-            HowToUse("How to use this App", {}) // 使い方ボタン
+            HowToUse("How to use this App", onUsageClick) // 使い方ボタン
         }
     }
 

--- a/main/app/src/main/java/com/example/seatassist/ui/usage/UsageScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/usage/UsageScreen.kt
@@ -1,0 +1,41 @@
+package com.example.seatassist.ui.usage
+
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun UsageScreen(
+    onNavigationClick: () -> Unit
+) {
+    Scaffold(
+        topBar = { UsageTopBar(onNavigationClick = onNavigationClick) },
+        backgroundColor = MaterialTheme.colors.primary,
+        contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.primary)
+    )
+    {
+        Text(
+            text = "How to use seat assist!!!",
+            fontSize = 30.sp,
+            style = MaterialTheme.typography.h4
+        )
+    }
+}
+
+@Composable
+fun UsageTopBar(onNavigationClick: () -> Unit) {
+    TopAppBar(
+        title = { Text(text = "How to use Seat Assist") },
+        navigationIcon = {
+            IconButton(onClick = { onNavigationClick() }) {
+                Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "back button")
+            }
+        },
+        elevation = 0.dp,
+        backgroundColor = MaterialTheme.colors.primary,
+        contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.primary)
+    )
+}


### PR DESCRIPTION
# 概要
使い方画面を作成
本プルリクは以下まで
- [x] 使い方画面のみ作成する
- [x] onClick処理を加える
- [ ] ボックスを作成
- [ ] ボックスを横にスライドできるようにする
- [ ] ボックス横にボタンを配置し
- [ ] ボタンを押すとボックス1個分ずれる
- [ ] 使い方テキストを作成
- [ ] 使い方がぞうを作成
- [ ] 使い方画面にテキストと画像を反映

# 変更点（UIに変更があればスクショを貼る）
使い方画面を作成
**画面だけなのでスクショはなし

# Issue
#22 

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
