### PR TITLE
トーストの作成

### DIFF
--- a/main/app/src/main/java/com/example/seatassist/ui/components/CommonUi.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/components/CommonUi.kt
@@ -2,27 +2,21 @@ package com.example.seatassist.ui.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ComposeCompilerApi
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -30,9 +24,13 @@ import kotlin.math.max
 
 /**
 メニュータイトル
-**/
+ **/
 @Composable
-fun MainPlaceholder(text: String, textAlign: TextAlign = TextAlign.End, fontSize: TextUnit = 16.sp) {
+fun MainPlaceholder(
+    text: String,
+    textAlign: TextAlign = TextAlign.End,
+    fontSize: TextUnit = 16.sp
+) {
     Text(
         text = text,
         modifier = Modifier.fillMaxWidth(),
@@ -45,7 +43,7 @@ fun MainPlaceholder(text: String, textAlign: TextAlign = TextAlign.End, fontSize
 
 /**
 メニュー内のボタン
-**/
+ **/
 @Composable
 fun MainButton(
     text: String,
@@ -91,7 +89,7 @@ fun MainEditText(
     editText: String,
     placeholderText: String,
     onEditText: (String) -> Unit
-    ) {
+) {
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -134,7 +132,7 @@ fun MainEditText(
 
 /**
 メインメニューの分断ライン
-**/
+ **/
 @Composable
 fun MainDivider() {
     Divider(
@@ -147,7 +145,7 @@ fun MainDivider() {
 
 /**
 メニューの説明文（少し薄いやつ）
-**/
+ **/
 @Composable
 fun SubText(
     text: String,
@@ -188,7 +186,8 @@ fun MembersCustomLayout(
             .coerceIn(constraints.minWidth.rangeTo(constraints.maxWidth))
 
         val height = columnHeight.maxOrNull()
-            ?.coerceIn(constraints.minHeight.rangeTo(constraints.maxHeight)) ?: constraints.minHeight
+            ?.coerceIn(constraints.minHeight.rangeTo(constraints.maxHeight))
+            ?: constraints.minHeight
 
         val columnX = IntArray(columns) { 0 }
         for (i in 1 until columns) {
@@ -210,4 +209,47 @@ fun MembersCustomLayout(
             }
         }
     }
+}
+
+@Composable
+fun SAAlertDialog(
+    title: String,
+    text: String,
+    primaryColor: Color,
+    onPrimaryColor: Color,
+    openDialog: MutableState<Boolean>
+) {
+    AlertDialog(
+        onDismissRequest = { },
+        backgroundColor = primaryColor,
+        shape = RoundedCornerShape(10.dp),
+        title = {
+            Text(
+                text = title,
+                color = onPrimaryColor,
+                fontSize = 20.sp,
+
+                )
+        },
+        text = {
+            Text(
+                text = text,
+                color = LocalContentColor.current.copy(alpha = ContentAlpha.disabled)
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    openDialog.value = false
+                }
+            ) {
+                Text(
+                    text = "OK",
+                    color = onPrimaryColor,
+                    fontSize = 15.sp
+                )
+            }
+        },
+        dismissButton = null
+    )
 }


### PR DESCRIPTION
# 概要
例外処理時に表示するトーストを作成

# 変更点（UIに変更があればスクショを貼る）
commonUIにToastを作成
> ## 呼び出し側

デフォルト値が```fault```の変数```openDialog```を用意．
任意のタイミングでtrueに変換する．

<img src="https://user-images.githubusercontent.com/80777762/137873686-7d37f521-fc62-4cab-9af8-9207090f23e5.png" width=full>

if 文でt```openDialog```がtrueだった場合に```SAAlertDialog```を呼び出す

<img src="https://user-images.githubusercontent.com/80777762/137874452-3236a418-3c33-4e16-a69d-56e8025153f3.png" width=full>

> ## UI
<img src="https://user-images.githubusercontent.com/80777762/137873427-63930fd4-98b3-45a2-9b9d-4176a80a31ef.gif" width=200>

# Issue
#37

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
