### PR TITLE
Members/make number of members screen

### DIFF
--- a/main/app/src/main/java/com/example/seatassist/MainActivity.kt
+++ b/main/app/src/main/java/com/example/seatassist/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -20,6 +19,7 @@ import com.example.seatassist.ui.lottery.LotteryScreen
 import com.example.seatassist.ui.main.MainScreen
 import com.example.seatassist.ui.main.MainViewModel
 import com.example.seatassist.ui.members.MembersScreen
+import com.example.seatassist.ui.members.NumberScreen
 import com.example.seatassist.ui.splash.SplashScreen
 import com.example.seatassist.ui.start.StartScreen
 import com.example.seatassist.ui.theme.SeatAssistTheme
@@ -52,7 +52,7 @@ fun SeatAssistApp(mainViewModel: MainViewModel) {
     val navController = rememberNavController()
     val darkIcons = MaterialTheme.colors.isLight
     // ステータスバー，ナビゲーションバーの色を指定
-    SideEffect{
+    SideEffect {
         systemUiController.setSystemBarsColor(
             color = pickledBlueWood,
             darkIcons = darkIcons
@@ -86,20 +86,20 @@ fun SeatAssistNavHost(
         startDestination = SeatAssistScreen.Splash.name,
         modifier = modifier
     ) {
-        composable(route = SeatAssistScreen.Start.name){
+        composable(route = SeatAssistScreen.Start.name) {
             StartScreen(
-                onUsageClick = { navController.navigate(SeatAssistScreen.Usage.name)},
+                onUsageClick = { navController.navigate(SeatAssistScreen.Usage.name) },
                 onStartClick = { navController.navigate(SeatAssistScreen.Main.name) }
             )
         }
-        composable(route = SeatAssistScreen.Splash.name){
+        composable(route = SeatAssistScreen.Splash.name) {
             SplashScreen(
                 navController = navController
             )
         }
         composable(route = SeatAssistScreen.Usage.name) {
             // Usage Compose
-            UsageScreen (
+            UsageScreen(
                 onNavigationClick = { navController.navigate(SeatAssistScreen.Start.name) }
             )
         }
@@ -133,11 +133,20 @@ fun SeatAssistNavHost(
                 onAddMemberOne = mainViewModel::addMemberOne,
                 onRemoveMember = mainViewModel::removeMember,
                 onEditName = mainViewModel::editName,
-                onEditNumber = mainViewModel::editNumber,
-                onCompletionNumber = mainViewModel::completionNumber,
-                onNavigationClick = { navController.navigate(SeatAssistScreen.Main.name) }
+                onNavigationClick = { navController.navigate(SeatAssistScreen.Main.name) },
+                onNumberNavigation = { navController.navigate(SeatAssistScreen.MembersNumber.name) }
             )
         }
+        composable(route = SeatAssistScreen.MembersNumber.name) {
+            NumberScreen(
+                numberText = mainViewModel.numberText.value,
+                onEditNumber = mainViewModel::editNumber,
+                onCompletionNumber = mainViewModel::completionNumber,
+                onNoChangeMembers = mainViewModel::noChangeMembers,
+                onNavigationClick = { navController.navigate(SeatAssistScreen.Members.name) }
+            )
+        }
+
         composable(route = SeatAssistScreen.Custom.name) {
             // Custom Compose
             CustomScreen(

--- a/main/app/src/main/java/com/example/seatassist/SeatAssistScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/SeatAssistScreen.kt
@@ -3,6 +3,7 @@ package com.example.seatassist
 enum class SeatAssistScreen() {
     Main(),
     Members(),
+    MembersNumber(),
     Lottery(),
     Custom(),
     Start(),

--- a/main/app/src/main/java/com/example/seatassist/ui/components/CommonUi.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/components/CommonUi.kt
@@ -11,24 +11,17 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ComposeCompilerApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.consumeAllChanges
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.*
@@ -42,7 +35,8 @@ import kotlin.math.roundToInt
 fun MainPlaceholder(
     text: String,
     textAlign: TextAlign = TextAlign.End,
-    fontSize: TextUnit = 16.sp
+    fontSize: TextUnit = 16.sp,
+    color: Color = MaterialTheme.colors.primary
 ) {
     Text(
         text = text,
@@ -50,7 +44,7 @@ fun MainPlaceholder(
         textAlign = textAlign,
         style = MaterialTheme.typography.h4,
         fontSize = fontSize,
-        color = MaterialTheme.colors.primary.copy(alpha = ContentAlpha.medium)
+        color = color.copy(alpha = ContentAlpha.medium)
     )
 }
 
@@ -80,7 +74,8 @@ fun MainButton(
                 contentColor = contentColor
             ),
             border = BorderStroke(color = borderColor, width = 1.dp),
-            elevation = ButtonDefaults.elevation(defaultElevation = 8.dp)
+            elevation = ButtonDefaults.elevation(defaultElevation = 8.dp),
+            shape = RoundedCornerShape(8.dp)
         ) {
             Text(
                 text = text,
@@ -192,12 +187,14 @@ fun MainDivider() {
 @Composable
 fun SubText(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Start
 ) {
     Text(
         text = text,
         color = LocalContentColor.current.copy(alpha = ContentAlpha.disabled),
         style = MaterialTheme.typography.caption,
+        textAlign = textAlign,
         modifier = modifier
     )
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
@@ -26,7 +26,7 @@ class MainViewModel : ViewModel() {
 
     var color = mutableStateOf(Color(0xFFDBD2AC))
 
-    fun addObject(id: Int, name:String, OffsetX: Float, OffsetY: Float, color: Color, size: Dp) {
+    fun addObject(id: Int, name: String, OffsetX: Float, OffsetY: Float, color: Color, size: Dp) {
         offsetList.add(
             OffsetData(
                 id,
@@ -127,5 +127,11 @@ class MainViewModel : ViewModel() {
     // Lottery Screen
     fun shuffleList() {
         membersList.shuffle()
+    }
+
+
+    // Number Screen
+    fun noChangeMembers() {
+        numberText.value = numberTextNoneVisi.value.toString()
     }
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/members/MembersScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/members/MembersScreen.kt
@@ -1,5 +1,6 @@
 package com.example.seatassist.ui.members
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -9,6 +10,7 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForwardIos
 import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,7 +24,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.seatassist.data.MembersData
-import com.example.seatassist.ui.components.*
+import com.example.seatassist.ui.components.MainButton
+import com.example.seatassist.ui.components.MainPlaceholder
+import com.example.seatassist.ui.components.MembersCustomLayout
+import com.example.seatassist.ui.components.SubText
 
 @ExperimentalMaterialApi
 @ExperimentalComposeUiApi
@@ -35,9 +40,8 @@ fun MembersScreen(
     onAddMemberOne: (Int, String) -> Unit,
     onRemoveMember: (Int) -> Unit,
     onEditName: (Int, String) -> Unit,
-    onEditNumber: (String) -> Unit,
-    onCompletionNumber: (Int) -> Unit,
-    onNavigationClick: () -> Unit
+    onNavigationClick: () -> Unit,
+    onNumberNavigation: () -> Unit
 ) {
     BackdropScaffold(
         appBar = {
@@ -71,8 +75,8 @@ fun MembersScreen(
         frontLayerContent = {
             MembersNumber(
                 numberText = numberText,
-                onEditNumber = onEditNumber,
-                onCompletionNumber = onCompletionNumber
+                onNavigationClick = onNavigationClick,
+                onNumberNavigation = onNumberNavigation
             )
         },
         scaffoldState = rememberBackdropScaffoldState(initialValue = BackdropValue.Revealed),
@@ -85,7 +89,6 @@ fun MembersScreen(
         frontLayerScrimColor = Color.Unspecified,
         frontLayerShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         frontLayerElevation = 8.dp
-
     )
 }
 
@@ -126,7 +129,8 @@ fun MembersItem(
     val focusManager = LocalFocusManager.current
 
     BoxWithConstraints {
-        val itemWidth = ((with(LocalDensity.current) { constraints.maxWidth.toDp()}).value * 0.3).dp
+        val itemWidth =
+            ((with(LocalDensity.current) { constraints.maxWidth.toDp() }).value * 0.3).dp
 
         Surface(
             shape = RoundedCornerShape(8.dp),
@@ -142,13 +146,19 @@ fun MembersItem(
                     value = name,
                     onValueChange = { onEditName(id, it) },
                     modifier = Modifier.weight(8F),
-                    placeholder = { MainPlaceholder(text = "Input text", textAlign = TextAlign.Start, fontSize = 15.sp) },
+                    placeholder = {
+                        MainPlaceholder(
+                            text = "Input text",
+                            textAlign = TextAlign.Start,
+                            fontSize = 15.sp
+                        )
+                    },
                     textStyle = MaterialTheme.typography.h4.copy(
                         fontSize = 20.sp,
                         textAlign = TextAlign.Center,
                     ),
                     singleLine = true,
-                    colors =  TextFieldDefaults.textFieldColors(
+                    colors = TextFieldDefaults.textFieldColors(
                         backgroundColor = Color.Transparent,
                         focusedIndicatorColor = Color.Transparent,
                         unfocusedIndicatorColor = Color.Transparent,
@@ -180,8 +190,8 @@ fun MembersItem(
 @Composable
 fun MembersNumber(
     numberText: String,
-    onEditNumber: (String) -> Unit,
-    onCompletionNumber: (Int) -> Unit
+    onNavigationClick: () -> Unit,
+    onNumberNavigation: () -> Unit
 ) {
     Column {
         Text(
@@ -199,18 +209,49 @@ fun MembersNumber(
                 bottom = 16.dp
             )
         )
-        MainEditText(
-            text = "Number of members",
-            editText = if (numberText == "0") "" else numberText,
-            placeholderText = "Input number",
-            onEditText = onEditNumber
-        )
+        MembersNumberItem(numberText = numberText, onNumberNavigation = onNumberNavigation)
         MainButton(
             text = "Completion",
             color = MaterialTheme.colors.primary,
             contentColor = MaterialTheme.colors.onPrimary,
             borderColor = MaterialTheme.colors.onPrimary,
-            onClick = { onCompletionNumber(numberText.toInt()) }
+            onClick = { onNavigationClick() }
         )
+    }
+}
+
+@Composable
+fun MembersNumberItem(
+    numberText: String,
+    onNumberNavigation: () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onNumberNavigation() }
+    ) {
+        Text(
+            text = "Number of members",
+            style = MaterialTheme.typography.h4,
+            fontSize = 20.sp,
+            modifier = Modifier.padding(16.dp)
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = numberText,
+                style = MaterialTheme.typography.h4,
+                color = LocalContentColor.current.copy(alpha = ContentAlpha.disabled),
+                fontSize = 20.sp,
+                modifier = Modifier.padding(16.dp)
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowForwardIos,
+                contentDescription = "number of members",
+                tint = LocalContentColor.current.copy(alpha = ContentAlpha.disabled)
+            )
+        }
     }
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/members/NumberScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/members/NumberScreen.kt
@@ -1,0 +1,122 @@
+package com.example.seatassist.ui.members
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.seatassist.ui.components.CommonTopBar
+import com.example.seatassist.ui.components.MainButton
+import com.example.seatassist.ui.components.MainPlaceholder
+import com.example.seatassist.ui.components.SubText
+
+@ExperimentalComposeUiApi
+@Composable
+fun NumberScreen(
+    numberText: String,
+    onEditNumber: (String) -> Unit,
+    onCompletionNumber: (Int) -> Unit,
+    onNavigationClick: () -> Unit,
+    onNoChangeMembers: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            CommonTopBar(onNavigationClick = {
+                onNoChangeMembers()
+                onNavigationClick()
+            }, title = "Number of Members")
+        },
+        backgroundColor = MaterialTheme.colors.primary,
+        contentColor = contentColorFor(backgroundColor = MaterialTheme.colors.primary)
+    ) {
+        Column {
+            Text(
+                text = "Please enter the number of members.",
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                style = MaterialTheme.typography.h6,
+                fontSize = 34.sp,
+                textAlign = TextAlign.Center
+            )
+            SubText(
+                text = "TextField with the number of members will be displayed in the Members screen.",
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp)
+            )
+            Text(
+                text = "Number of members",
+                style = MaterialTheme.typography.h4,
+                fontSize = 20.sp,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+            )
+            NumberMemberEdit(
+                numberText = numberText,
+                onEditNumber = onEditNumber,
+                onCompletionNumber = onCompletionNumber,
+                onNavigationClick = onNavigationClick
+            )
+        }
+    }
+}
+
+@ExperimentalComposeUiApi
+@Composable
+fun NumberMemberEdit(
+    numberText: String,
+    onEditNumber: (String) -> Unit,
+    onCompletionNumber: (Int) -> Unit,
+    onNavigationClick: () -> Unit
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    TextField(
+        value = if (numberText == "0") "" else numberText,
+        onValueChange = { onEditNumber(it) },
+        placeholder = {
+            MainPlaceholder(
+                text = "Input number",
+                fontSize = 15.sp,
+                color = MaterialTheme.colors.onPrimary,
+                textAlign = TextAlign.Start
+            )
+        },
+        textStyle = MaterialTheme.typography.h6.copy(fontSize = 26.sp),
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = MaterialTheme.colors.primaryVariant,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            disabledTextColor = Color.Transparent
+        ),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+        keyboardActions = KeyboardActions(onDone = {
+            keyboardController?.hide()
+            focusManager.clearFocus()
+        }),
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier
+            .padding(start = 16.dp, end = 16.dp)
+            .fillMaxWidth()
+    )
+    MainButton(
+        text = "Change members",
+        color = MaterialTheme.colors.onPrimary,
+        contentColor = MaterialTheme.colors.primary,
+        onClick = {
+            onCompletionNumber(numberText.toInt())
+            onNavigationClick()
+        }
+    )
+}


### PR DESCRIPTION
# 概要
・member画面の変更
・number of members画面のUIとロジックの作成

# 変更点（UIに変更があればスクショを貼る）
## member画面の変更
Number of memersをTextFieldからTextに変更．メンバーの数を薄く表示させるようにした．
<img src="https://user-images.githubusercontent.com/81143699/138134468-7ae54d10-7403-40bb-b5bb-a292d242b307.png" width=300>

## number of members画面のUIとロジックの作成
change membersをトリガーに席の数を変更する．戻るアイコンを押すと変更は保持されず，以前の席の数に戻るうように設計．
<img src="https://user-images.githubusercontent.com/81143699/138136754-79f3d409-b801-40f1-b524-d8de9ccf85ce.png" width=300>

# Issue
Issueやコンフル

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
