### PR TITLE
スタート画面に動画の追加

### DIFF
--- a/main/app/build.gradle
+++ b/main/app/build.gradle
@@ -78,4 +78,7 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager:0.19.0"
     implementation "com.google.accompanist:accompanist-pager-indicators:0.19.0"
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.19.0"
+
+    // lottie
+    implementation "com.airbnb.android:lottie-compose:4.1.0"
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/splash/SplashScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/splash/SplashScreen.kt
@@ -15,10 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.example.seatassist.R
 import com.example.seatassist.SeatAssistScreen
@@ -30,15 +27,15 @@ fun SplashScreen(
     navController: NavController,
     systemUiController: SystemUiController
 ) {
-    val Sidecar = MaterialTheme.colors.primary
+    val sidecar = MaterialTheme.colors.primary
     val darkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setStatusBarColor(
-            color = Sidecar,
+            color = sidecar,
             darkIcons = darkIcons
         )
         systemUiController.setNavigationBarColor(
-            color = Sidecar,
+            color = sidecar,
             darkIcons = darkIcons
         )
     }

--- a/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
@@ -1,17 +1,20 @@
 package com.example.seatassist.ui.start
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.airbnb.lottie.compose.*
 import com.example.seatassist.R
 import com.example.seatassist.ui.components.fontsBold
 import com.example.seatassist.ui.components.fontsNormal
@@ -24,8 +27,8 @@ import com.google.accompanist.systemuicontroller.SystemUiController
 @ExperimentalMaterialApi
 @Composable
 fun StartScreen(
-    onUsageClick:() -> Unit,
-    onStartClick:() -> Unit,
+    onUsageClick: () -> Unit,
+    onStartClick: () -> Unit,
     systemUiController: SystemUiController
 ) {
     val Sidecar = MaterialTheme.colors.primary
@@ -66,7 +69,7 @@ fun StartScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
-                    ChairImg()  // 椅子の画像を挿入
+                    LottieLoader()
                 }
             }
             StartButton("Start", onStartClick)    // スタートボタン
@@ -126,15 +129,32 @@ fun HowToUse(text: String, onClick: () -> Unit) {
 }
 
 /**
- * 椅子の画像
+ * 椅子アニメーション
  */
 @Composable
-fun ChairImg() {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Image(
-            painter = painterResource(id = R.drawable.chair_backcolor_yellow_hhd),
-            contentDescription = "chair image",
-            modifier = Modifier.size(500.dp)
+fun LottieLoader() {
+    val compositionResult: LottieCompositionResult = rememberLottieComposition(
+        spec = LottieCompositionSpec.RawRes(
+            R.raw.startmovie
         )
-    }
+    )
+    val progress by animateLottieCompositionAsState(
+        composition = compositionResult.value,
+        isPlaying = true,
+        iterations = LottieConstants.IterateForever,
+        speed = 1.0f
+    )
+
+    LottieAnimation(
+        compositionResult.value,
+        progress,
+        modifier = Modifier
+            .padding(top = 30.dp, bottom = 50.dp, start = 40.dp, end = 40.dp)
+            .clip(CircleShape)
+            .border(
+                width = 4.dp,
+                color = MaterialTheme.colors.onPrimary,
+                shape = CircleShape
+            )
+    )
 }


### PR DESCRIPTION
# 概要
スタート画面にlottiejsonの動画を挿入

# 変更点（UIに変更があればスクショを貼る）
> ## UI
### 変更前

椅子の静止画
<img src="https://user-images.githubusercontent.com/80777762/139873784-93455cbd-dbc2-4e53-b7b1-98bf4af3a9ea.png" width=200>

### 変更後

1. blenderで作成したmp4をjsonに変換
2. lottieアニメーションで挿入
<img src="https://user-images.githubusercontent.com/80777762/139874256-4abf2114-b77f-438c-a8d1-2001418800dd.gif" width=200>

> jsonファイルの保存場所

res/rawのフォルダに保存
<img src="https://user-images.githubusercontent.com/80777762/139873030-53c87168-c923-450c-9276-97ff09cceccf.png" width=300>

start.ktの以下にidを指定する
<img src="https://user-images.githubusercontent.com/80777762/139872765-dddf5dfe-6810-4d83-9c9d-16b2c9886fb4.png" width=full>


> mov, mp4 to lottie.json
https://isotropic.co/video-to-lottie/

# Issue
#64 

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
