### PR TITLE
All/object control mac

### DIFF
--- a/main/app/src/main/java/com/example/seatassist/ui/lottery/LotteryScreen.kt.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/lottery/LotteryScreen.kt.kt
@@ -15,18 +15,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.seatassist.MainActivity
 import com.example.seatassist.data.MembersData
 import com.example.seatassist.data.OffsetData
 import com.example.seatassist.ui.components.BottomBarButton
 import com.example.seatassist.ui.components.DragBox
+import com.example.seatassist.ui.components.fontsBold
 import com.example.seatassist.ui.components.fontsNormal
+import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsHeight
+import com.google.accompanist.insets.rememberInsetsPaddingValues
 
 @Composable
 fun LotteryScreen(
+    screenHeight: Float,
     membersList: List<MembersData>,
     offsetList: List<OffsetData>,
     onMoveOffsetX: (Int, Float) -> Unit,
@@ -35,25 +42,25 @@ fun LotteryScreen(
     onNavigationClick: () -> Unit
 ) {
     Scaffold(
-        backgroundColor = MaterialTheme.colors.onPrimary,
-        contentColor = MaterialTheme.colors.primary,
-        bottomBar = { Spacer(Modifier.navigationBarsHeight().fillMaxWidth())
+        topBar = { LotteryAppBar(title = "Lottery Result",) },
+        backgroundColor = MaterialTheme.colors.primary,
+        contentColor = MaterialTheme.colors.onPrimary,
+        bottomBar = { Spacer(
+            Modifier
+                .navigationBarsHeight()
+                .fillMaxWidth())
         }
     ) { contentPadding ->
         Column(
             modifier = Modifier
                 .padding(contentPadding)
-                .padding(top = 16.dp)
                 .verticalScroll(rememberScrollState())
         ) {
             Box(
                 modifier = Modifier
-                    .padding(16.dp)
+                    .padding(start = 16.dp, end = 16.dp)
                     .fillMaxWidth()
-                    .height(575.dp)
-                    .clip(shape = RoundedCornerShape(16.dp))
-                    .background(color = MaterialTheme.colors.primary)
-
+                    .height(screenHeight.dp)
             ) {
                 offsetList.forEachIndexed { index, offsetData ->
                     DragBox(
@@ -105,6 +112,35 @@ fun LotteryScreen(
                     modifier = Modifier.clickable { onShuffleList() }
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun LotteryAppBar(
+    title: String,
+    backgroundColor: Color = MaterialTheme.colors.primary,
+    contentColor: Color = contentColorFor(backgroundColor = MaterialTheme.colors.primary)
+) {
+    TopAppBar(
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        contentPadding = rememberInsetsPaddingValues(
+            insets = LocalWindowInsets.current.statusBars,
+            applyBottom = false
+        ),
+        elevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                fontFamily = fontsBold,
+                color = contentColor
+            )
         }
     }
 }

--- a/main/app/src/main/java/com/example/seatassist/ui/main/MainScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/main/MainScreen.kt
@@ -59,7 +59,7 @@ fun MainScreen(
         backLayerContent = {
             Box(
                 modifier = Modifier
-                    .padding(16.dp)
+                    .padding(start = 16.dp, end = 16.dp)
                     .fillMaxSize()
                     .pointerInput(Unit) {
                         detectTapGestures {

--- a/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.seatassist.ui.main
 
+import android.content.Context
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
@@ -10,7 +11,10 @@ import com.example.seatassist.data.MembersData
 import com.example.seatassist.data.OffsetData
 import com.example.seatassist.data.ScaleData
 
-class MainViewModel : ViewModel() {
+class MainViewModel(
+    private val screenWidth: Float,
+    private val screenHeight: Float,
+    private val context: Context) : ViewModel() {
 
     var numberText = mutableStateOf("0")
     var numberTextNoneVisi = mutableStateOf(0)
@@ -18,7 +22,6 @@ class MainViewModel : ViewModel() {
     fun editNumber(newNumber: String) {
         numberText.value = newNumber
     }
-
 
     var offsetList = mutableStateListOf<OffsetData>()
 
@@ -53,11 +56,21 @@ class MainViewModel : ViewModel() {
     }
 
     fun moveOffsetX(id: Int, newOffsetX: Float) {
-        offsetList[id].offsetX.value += newOffsetX
+        val density = context.resources.displayMetrics.density
+        val x = (offsetList[id].offsetX.value) / density
+        val size = offsetList[id].size
+        if ((x > 0 && x < screenWidth - size.value) || (x <= 0 && newOffsetX >= 0) || (x >= screenWidth - size.value && newOffsetX <= 0)) {
+            offsetList[id].offsetX.value += newOffsetX
+        }
     }
 
     fun moveOffsetY(id: Int, newOffsetY: Float) {
-        offsetList[id].offsetY.value += newOffsetY
+        val density = context.resources.displayMetrics.density
+        val y = (offsetList[id].offsetY.value) / density
+        val size = offsetList[id].size
+        if ((y > 0 && y < screenHeight - size.value) || (y < 0 && newOffsetY >= 0) || (y >= screenWidth - size.value && newOffsetY <= 0)) {
+            offsetList[id].offsetY.value += newOffsetY
+        }
     }
 
 

--- a/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModelFactory.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/main/MainViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.example.seatassist.ui.main
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class MainViewModelFactory(
+    private val screenWidth: Float,
+    private val screenHeight: Float,
+    private val context: Context
+): ViewModelProvider.Factory {
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+            return MainViewModel(
+                screenWidth = screenWidth,
+                screenHeight = screenHeight,
+                context = context
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/main/app/src/main/java/com/example/seatassist/ui/number/NunmberScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/number/NunmberScreen.kt
@@ -1,2 +1,0 @@
-package com.example.seatassist.ui.number
-


### PR DESCRIPTION
# 概要
・オブジェクトの移動範囲を制限
・Lottery画面のUIを変更，Main画面のオブジェクトが表示される位置が一致しないバグを修正

# 変更点（UIに変更があればスクショを貼る）
## オブジェクトの移動範囲を制限
MainScreen・LotteryScreenでオブジェクトが親コンポーネントのBoxの範囲外に行かないように設定．MainViewModel の"moveOffsetX"と"moveOffsetY"の分岐文で制限している．densityはpxをdpに変換するために使用している．
<img src="https://user-images.githubusercontent.com/81143699/140638967-16d162a8-89ea-4498-a136-4e858099ebeb.png" >

## Lottery画面のUIを変更，Main画面のオブジェクトが表示される位置と一致しないバグを修正
Lottery画面のUIをシンプルにした．Lottery画面にAppBarを挿入し，Main画面とBoxのpaddingを合わせることで，オブジェクトが表示される位置と一致しないバグを解消した。
<img src="https://user-images.githubusercontent.com/81143699/140639280-6e37baf7-8538-4d04-b6c7-df03765e41b5.png" width=300>


# Issue
#67 #62 

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
