### PR TITLE
スタート画面のアニメーションサイズを変更

### DIFF
--- a/main/app/src/main/java/com/example/seatassist/MainActivity.kt
+++ b/main/app/src/main/java/com/example/seatassist/MainActivity.kt
@@ -62,7 +62,7 @@ class MainActivity : ComponentActivity() {
         } else {
             val defaultDisplay = windowManager.defaultDisplay
             screenWidth = defaultDisplay.width / density - 32
-            screenHeight = defaultDisplay.height / density
+            screenHeight = defaultDisplay.height / density - 250
         }
 
         // viewModelのインスタンスを作成

--- a/main/app/src/main/java/com/example/seatassist/ui/lottery/LotteryScreen.kt.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/lottery/LotteryScreen.kt.kt
@@ -1,10 +1,8 @@
 package com.example.seatassist.ui.lottery
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -14,13 +12,10 @@ import androidx.compose.material.icons.filled.ReplayCircleFilled
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.seatassist.MainActivity
 import com.example.seatassist.data.MembersData
 import com.example.seatassist.data.OffsetData
 import com.example.seatassist.ui.components.BottomBarButton

--- a/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
+++ b/main/app/src/main/java/com/example/seatassist/ui/start/StartScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.airbnb.lottie.compose.*
@@ -38,7 +39,8 @@ fun StartScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(contentPadding),
+                .padding(contentPadding)
+                .padding(top = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         )
@@ -48,15 +50,11 @@ fun StartScreen(
                 fontSize = 60.sp,
                 fontFamily = fontsBold
             )
-            Box(
-                modifier = Modifier
-                    .size(400.dp)
-            ) {
-                Column(
+            BoxWithConstraints {
+                val boxWidth = with(LocalDensity.current) { constraints.maxWidth.toDp() }
+                Box(
                     modifier = Modifier
-                        .fillMaxHeight(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
+                        .size(boxWidth)
                 ) {
                     LottieLoader()
                 }


### PR DESCRIPTION
# 概要
・スタート画面のアニメーションのサイズを変更

# 変更点（UIに変更があればスクショを貼る）
細かい変更点
## スタート画面のアニメーションのサイズを変更
スタート画面のアニメーションが端末によってつぶれて見えるバグを修正．横幅を，親のコンポーネントの最大幅に設定することでこの問題を解消した

### 修正後のコードの概要
<img src="https://user-images.githubusercontent.com/81143699/142133307-ef2257b5-05a4-46a2-88a1-c1920de1f3a8.png">

## 修正前のUI
<img src="https://user-images.githubusercontent.com/81143699/142133999-8feddf7c-bacb-499b-a6e5-862542669916.jpg" width=300>

## 修正後のUI
<img src="https://user-images.githubusercontent.com/81143699/142134092-c77154a1-04bb-4154-b61c-d1f1cd9493ba.jpg" width=300>

# Issue
Issueやコンフル

# 動作確認OS
- [ ] 10.x
- [x] 11.x
- [ ] other
